### PR TITLE
Fix: Bugs 6-2-23

### DIFF
--- a/src/features/setups/SingleSetup/SingleRecordDialog.js
+++ b/src/features/setups/SingleSetup/SingleRecordDialog.js
@@ -128,7 +128,7 @@ function SingleRecordDialog({
         if (isSetup) {
             res = await updateRowNoteSetup({
                 setupId,
-                rowId: rowRecord.index,
+                rowId: rowRecord.rowId,
                 note: editor?.getHTML(),
                 images,
                 isSync,
@@ -168,6 +168,7 @@ function SingleRecordDialog({
     useEffect(() => {
         editor?.commands.setContent(rowRecord?.note || "");
         setImages(rowRecord?.imgs || []);
+        setMsg("");
     }, [rowRecord, editor]);
 
     return (


### PR DESCRIPTION
In `SingleRecordDialog`:
* Fix the key to pull the `rowId` from (depending on `Setup` or `Document`)
* Reset message when `rowId` changes